### PR TITLE
pyfmodex.studio wouldn't load on Linux, because of ctypes missing windll

### DIFF
--- a/pyfmodex/studio/library.py
+++ b/pyfmodex/studio/library.py
@@ -1,6 +1,6 @@
 import os
 import platform
-from ctypes import cdll, windll
+from ctypes import *
 
 arch = platform.architecture()[0]
 if os.name == 'nt':


### PR DESCRIPTION
this is a simple workaround for that