### PR TITLE
Implement using a custom, user-specified fmod dll path

### DIFF
--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -3,6 +3,7 @@ Installation
 
 To install, first make sure that you have the FMOD Engine library for you platform somewhere in your path, so Python will be able to find it.
 On Linux, libraries are searched for in `LD_LIBRARY_PATH`.
+Alternatively, you can set ``PYFMODEX_DLL_PATH`` as an environment variable to specify the library path. This can also be done inside Python setting ``os.environ["PYFMODEX_DLL_PATH"]`` before importing pyfmodex. 
 
 .. todo:: Add instructions for library paths on Mac OS X and Windows
 

--- a/pyfmodex/fmodex.py
+++ b/pyfmodex/fmodex.py
@@ -12,26 +12,29 @@ Raises a RuntimeError when that fails.
 import os
 import platform
 import sys
-from ctypes import *
+from ctypes import CDLL, windll
 
-arch = platform.architecture()[0]
-if platform.system() == "Windows":
-    try:
-        _dll = windll.fmod
-    except Exception as exc:
-        current_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+if os.environ.get("PYFMODEX_DLL_PATH") is not None:
+    _dll = CDLL(os.environ.get("PYFMODEX_DLL_PATH"))
+else:
+    arch = platform.architecture()[0]
+    if platform.system() == "Windows":
         try:
-            _dll = CDLL(os.path.join(current_directory, "fmod"))
-        except:
-            raise RuntimeError("Pyfmodex could not find the fmod library") from exc
+            _dll = windll.fmod
+        except Exception as exc:
+            current_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+            try:
+                _dll = CDLL(os.path.join(current_directory, "fmod"))
+            except:
+                raise RuntimeError("Pyfmodex could not find the fmod library") from exc
 
-elif platform.system() == "Linux":
-    _dll = CDLL("libfmod.so")
+    elif platform.system() == "Linux":
+        _dll = CDLL("libfmod.so")
 
-elif platform.system() == "Darwin":
-    if arch == "32bit":
-        raise RuntimeError("No 32-bit fmod library for Mac Os exists")
-    _dll = CDLL("libfmod.dylib")
+    elif platform.system() == "Darwin":
+        if arch == "32bit":
+            raise RuntimeError("No 32-bit fmod library for Mac Os exists")
+        _dll = CDLL("libfmod.dylib")
 from . import globalvars
 
 globalvars.DLL = _dll

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Installation
 ------------
 To install, first make sure that you have the FMOD Engine library for you platform somewhere in your path, so Python will be able to find it.
 On Linux, libraries are searched for in `LD_LIBRARY_PATH`.
+Alternatively you can set ``PYFMODEX_DLL_PATH`` as environment variable to specify the library path. This can also be done inside Python setting ``os.environ["PYFMODEX_DLL_PATH"]`` before importing pyfmodex. 
 To download the FMOD Engine library, visit http://www.fmod.org/download. The library is free to download, but requires a free account to be made first.
 
 Then, install pyfmodex via `pip`, `easy_install` or the `setup.py` way. Note that the minimum supported Python version is Python 3.6.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Installation
 ------------
 To install, first make sure that you have the FMOD Engine library for you platform somewhere in your path, so Python will be able to find it.
 On Linux, libraries are searched for in `LD_LIBRARY_PATH`.
-Alternatively you can set ``PYFMODEX_DLL_PATH`` as environment variable to specify the library path. This can also be done inside Python setting ``os.environ["PYFMODEX_DLL_PATH"]`` before importing pyfmodex. 
+Alternatively, you can set ``PYFMODEX_DLL_PATH`` as an environment variable to specify the library path. This can also be done inside Python setting ``os.environ["PYFMODEX_DLL_PATH"]`` before importing pyfmodex.
 To download the FMOD Engine library, visit http://www.fmod.org/download. The library is free to download, but requires a free account to be made first.
 
 Then, install pyfmodex via `pip`, `easy_install` or the `setup.py` way. Note that the minimum supported Python version is Python 3.6.


### PR DESCRIPTION
This PR implements a way to specify the fmod lib that pyfmodex should load.
It does so by using the environment variables. If ``PYFMODEX_DLL_PATH`` is set as environment variable, then pyfmodex will load the fmod lib from the value of this environment variable. If ``PYFMODEX_DLL_PATH`` is not set, then the default lookup code is used. Therefore this PR doesn't break existing code.

It resolves #44 

(This has to be added as note to the merged PR details.)