### PR TITLE
In DSP_PARAMETER_FFT structure, where spectrum parameter has a wrong type.

### DIFF
--- a/pyfmodex/structures.py
+++ b/pyfmodex/structures.py
@@ -509,7 +509,7 @@ class DSP_PARAMETER_FFT(Structure):
     :ivar list(float) spectrum: Per channel spectrum arrays.
     """
 
-    _fields_ = [("length", c_int), ("numchannels", c_int), ("spectrum", c_float * 32)]
+    _fields_ = [("length", c_int), ("numchannels", c_int), ("spectrum", ctypes.POINTER(c_float) * 32)]
 
 
 class DSP_PARAMETER_OVERALLGAIN(Structure):

--- a/pyfmodex/structures.py
+++ b/pyfmodex/structures.py
@@ -1,5 +1,5 @@
 """Structures."""
-
+import ctypes
 # pylint: disable=too-few-public-methods
 # These are mostly data containers, really.
 
@@ -509,7 +509,7 @@ class DSP_PARAMETER_FFT(Structure):
     :ivar list(float) spectrum: Per channel spectrum arrays.
     """
 
-    _fields_ = [("length", c_int), ("numchannels", c_int), ("spectrum", ctypes.POINTER(c_float) * 32)]
+    _fields_ = [("length", c_int), ("numchannels", c_int), ("spectrum", POINTER(c_float) * 32)]
 
 
 class DSP_PARAMETER_OVERALLGAIN(Structure):

--- a/pyfmodex/structures.py
+++ b/pyfmodex/structures.py
@@ -1,5 +1,4 @@
 """Structures."""
-import ctypes
 # pylint: disable=too-few-public-methods
 # These are mostly data containers, really.
 


### PR DESCRIPTION
Fixed a bug in DSP_PARAMETER_FFT structure where spectrum parameter was miss-classified as a list of floats, while it's a list of float pointers.

https://www.fmod.com/docs/2.00/api/plugin-api-dsp.html#fmod_dsp_parameter_fft