### PR TITLE
Add `set_3d_attributes` and `get_3d_attributes` to EventInstance

### DIFF
--- a/pyfmodex/studio/event_instance.py
+++ b/pyfmodex/studio/event_instance.py
@@ -3,6 +3,8 @@
 from ctypes import byref, c_bool, c_float, c_int, c_void_p
 
 from ..channel_group import ChannelGroup
+from ..structures import THREED_ATTRIBUTES
+from ..structures import VECTOR
 from ..utils import prepare_str
 from .enums import PLAYBACK_STATE
 from .studio_object import StudioObject
@@ -73,6 +75,48 @@ class EventInstance(StudioObject):
         """
         self._call(
             "SetParameterByName", prepare_str(name), c_float(value), ignoreseekspeed
+        )
+
+    def get_3d_attributes(self) -> list[list[float]]:
+        """Get the 3D attributes of this EventInstance.
+
+        :returns: list of [`position`, `velocity`, `forward`, `up`]
+        """
+        _attrs = THREED_ATTRIBUTES(VECTOR(), VECTOR(), VECTOR(), VECTOR())
+        self._call(
+            "Get3DAttributes",
+            byref(_attrs)
+        )
+        return [
+            _attrs.position.to_list(),
+            _attrs.velocity.to_list(),
+            _attrs.forward.to_list(),
+            _attrs.up.to_list()
+        ]
+
+    def set_3d_attributes(
+            self,
+            position: list = [0, 0, 0],
+            velocity: list = [0, 0, 0],
+            forward: list = [0, 1, 0],
+            up: list = [0, 0, 1]
+        ):
+        """Set the 3D attributes for this EventInstance.
+
+        :param list position: Position used for panning and attenuation (camera relative).
+        :param list velocity: Velocity in world space used for doppler.
+        :param list forward: Forwards orientation, must be of unit length (1.0)
+            and perpendicular to `up`.
+        :param list up: Upwards orientation, must be of unit length (1.0) and
+            perpendicular to `forward`.
+        """
+        pos = VECTOR.from_list(position)
+        vel = VECTOR.from_list(velocity)
+        forward = VECTOR.from_list(forward)
+        up = VECTOR.from_list(up)
+        self._call(
+            "Set3DAttributes",
+            byref(THREED_ATTRIBUTES(pos, vel, forward, up))
         )
 
     @property

--- a/pyfmodex/studio/event_instance.py
+++ b/pyfmodex/studio/event_instance.py
@@ -15,6 +15,13 @@ class EventInstance(StudioObject):
 
     function_prefix = "FMOD_Studio_EventInstance"
 
+    def __init__(self, ptr):
+        self._pos = VECTOR()
+        self._vel = VECTOR()
+        self._fwd = VECTOR()
+        self._up = VECTOR()
+        super().__init__(ptr)
+
     def start(self):
         """Starts playback.
 
@@ -55,6 +62,69 @@ class EventInstance(StudioObject):
         state = c_int()
         self._call("GetPlaybackState", byref(state))
         return PLAYBACK_STATE(state.value)
+
+    @property
+    def position(self):
+        """Position in 3D space used for panning and attenuation.
+
+        :type: list of three coordinate floats
+        """
+        return self._pos.to_list()
+
+    @position.setter
+    def position(self, poslist):
+        self._pos = VECTOR.from_list(poslist)
+        self._commit_3d()
+
+    @property
+    def velocity(self):
+        """Velocity in 3D space used for doppler.
+
+        :type: list of three coordinate floats
+        """
+        return self._vel.to_list()
+
+    @velocity.setter
+    def velocity(self, vellist):
+        self._vel = VECTOR.from_list(vellist)
+        self._commit_3d()
+
+    @property
+    def forward(self):
+        """Forwards orientation.
+
+        :type: list of three coordinate floats
+        """
+        return self._fwd.to_list()
+
+    @forward.setter
+    def forward(self, fwdlist):
+        self._fwd = VECTOR.from_list(fwdlist)
+        self._commit_3d()
+
+    @property
+    def up(self):
+        """Upwards orientation.
+
+        :type: list of three coordinate floats
+        """
+        return self._up.to_list()
+
+    @up.setter
+    def up(self, uplist):
+        self._up = VECTOR.from_list(uplist)
+        self._commit_3d()
+
+    def _commit_3d(self):
+        self._call(
+            "Set3DAttributes",
+            byref(THREED_ATTRIBUTES(
+                self._pos,
+                self._vel,
+                self._fwd,
+                self._up
+            ))
+        )
 
     def get_parameter_by_name(self, name):
         """A parameter value.
@@ -110,14 +180,11 @@ class EventInstance(StudioObject):
         :param list up: Upwards orientation, must be of unit length (1.0) and
             perpendicular to `forward`.
         """
-        pos = VECTOR.from_list(position)
-        vel = VECTOR.from_list(velocity)
-        forward = VECTOR.from_list(forward)
-        up = VECTOR.from_list(up)
-        self._call(
-            "Set3DAttributes",
-            byref(THREED_ATTRIBUTES(pos, vel, forward, up))
-        )
+        self._pos = VECTOR.from_list(position)
+        self._vel = VECTOR.from_list(velocity)
+        self._fwd = VECTOR.from_list(forward)
+        self._up = VECTOR.from_list(up)
+        self._commit_3d()
 
     @property
     def channel_group(self):


### PR DESCRIPTION
This adds `Studio::EventInstance::set3DAttributes` and `Studio::EventInstance::get3DAttributes` bindings
If preferred I can wrap each attribute in a property similar to how it's done `System.Listener`